### PR TITLE
Add Multi-Board Treadmill Descriptors & BLE Advertise+Scan Test

### DIFF
--- a/.github/workflows/treadmill-ci-ble-test.yml
+++ b/.github/workflows/treadmill-ci-ble-test.yml
@@ -13,6 +13,7 @@
 # [1]: https://book.treadmill.ci/
 # [2]: https://github.com/treadmill-tb/treadmill
 # [3]: https://book.treadmill.ci/user-guide/github-actions-integration.html
+# TEST
 name: treadmill-ci-ble-test
 env:
   TERM: xterm # Makes tput work in actions output

--- a/.github/workflows/treadmill-ci-ble-test.yml
+++ b/.github/workflows/treadmill-ci-ble-test.yml
@@ -68,5 +68,5 @@ jobs:
       multi-board: 'true'
       supervisor-id: 'fb1384d5-e1a5-469c-beb4-0d4d215c9793'
       board-descriptors: >-
-        ../board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml ../board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
+        board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
     secrets: inherit

--- a/.github/workflows/treadmill-ci-ble-test.yml
+++ b/.github/workflows/treadmill-ci-ble-test.yml
@@ -1,7 +1,6 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
-
 # This workflow contains Treadmill-based hardware CI for nightly BLE testing.
 #
 # Treadmill is a distributed hardware testbed developed within the Tock OS
@@ -19,7 +18,7 @@ env:
   TERM: xterm # Makes tput work in actions output
 # Controls when the action will run.
 on:
-  # Manual trigger only
+  # Manual trigger
   workflow_dispatch:
     inputs:
       tock-kernel-ref:
@@ -30,6 +29,10 @@ on:
         description: 'Ref (revision/branch/tag) of the upstream libtock-c repo to test'
         required: true
         default: 'master'
+  # Add push trigger for your branch
+  push:
+    branches:
+      - dev/mult-board-treadmill
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/treadmill-ci-ble-test.yml
+++ b/.github/workflows/treadmill-ci-ble-test.yml
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+# This workflow contains Treadmill-based hardware CI for nightly BLE testing.
+#
+# Treadmill is a distributed hardware testbed developed within the Tock OS
+# project. For more information on Treadmill, have a look at its documentation
+# [1] or repository [2].
+#
+# This workflow specifically targets BLE advertising and scanning tests on multiple
+# boards attached to a specific supervisor.
+#
+# [1]: https://book.treadmill.ci/
+# [2]: https://github.com/treadmill-tb/treadmill
+# [3]: https://book.treadmill.ci/user-guide/github-actions-integration.html
+name: treadmill-ci-ble-test
+env:
+  TERM: xterm # Makes tput work in actions output
+# Controls when the action will run.
+on:
+  # Manual trigger only
+  workflow_dispatch:
+    inputs:
+      tock-kernel-ref:
+        description: 'Ref (revision/branch/tag) of the upstream Tock repo to test'
+        required: true
+        default: 'master'
+      libtock-c-ref:
+        description: 'Ref (revision/branch/tag) of the upstream libtock-c repo to test'
+        required: true
+        default: 'master'
+permissions:
+  contents: read
+jobs:
+  prepare-ble-test:
+    runs-on: ubuntu-latest
+    outputs:
+      # This is a fixed list containing just the BLE advertising and scanning test
+      hwci-tests-json: ${{ steps.prepare-test.outputs.hwci-tests-json }}
+    steps:
+      - name: Prepare BLE test
+        id: prepare-test
+        run: |
+          # Instead of analyzing changes, we specifically select the BLE test
+          echo 'hwci-tests-json=["tests/ble_advertising_scanning_test.py"]' >> "$GITHUB_OUTPUT"
+          echo "Selected test: tests/ble_advertising_scanning_test.py"
+  run-treadmill-ci:
+    needs: [prepare-ble-test]
+    uses: ./.github/workflows/treadmill-ci.yml
+    with:
+      # Only run on a specific repository
+      repository-filter: 'tock/tock-hardware-ci'
+      # Provide access to the required Treadmill secrets
+      job-environment: 'treadmill-ci'
+      # This workflow tests the tock-hardware-ci scripts itself, so take the
+      # current GITHUB_SHA:
+      tock-hardware-ci-ref: ${{ github.sha }}
+      # Use the provided upstream Tock kernel / userspace components:
+      tock-kernel-ref: ${{ inputs.tock-kernel-ref }}
+      libtock-c-ref: ${{ inputs.libtock-c-ref }}
+      # Pass our fixed test JSON
+      tests-json: ${{ needs.prepare-ble-test.outputs.hwci-tests-json }}
+      # Specify that this is for the BLE test which needs multiple boards
+      multi-board: 'true'
+      supervisor-id: 'fb1384d5-e1a5-469c-beb4-0d4d215c9793'
+      board-descriptors: >-
+        board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
+    secrets: inherit

--- a/.github/workflows/treadmill-ci-ble-test.yml
+++ b/.github/workflows/treadmill-ci-ble-test.yml
@@ -68,5 +68,5 @@ jobs:
       multi-board: 'true'
       supervisor-id: 'fb1384d5-e1a5-469c-beb4-0d4d215c9793'
       board-descriptors: >-
-        board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
+        ../board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml ../board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
     secrets: inherit

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -1,7 +1,6 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
-
 # This workflow contains all Treadmill-based hardware CI jobs.
 #
 # Treadmill is a distributed hardware testbed developed within the Tock OS
@@ -17,12 +16,9 @@
 # [2]: https://github.com/treadmill-tb/treadmill
 # [3]: https://book.treadmill.ci/user-guide/github-actions-integration.html
 #
-
 name: treadmill-ci
-
 env:
   TERM: xterm # Makes tput work in actions output
-
 on:
   workflow_call:
     inputs:
@@ -58,23 +54,17 @@ on:
         required: false
         type: string
         default: ''
-
 jobs:
   test-prepare:
     runs-on: ubuntu-latest
-
     # Do not run job on forks, as they will not have the correct environment set up
     if: github.repository == inputs.repository-filter
-
     environment: ${{ inputs.job-environment }}
-
     outputs:
       tml-job-ids: ${{ steps.treadmill-job-launch.outputs.tml-job-ids }}
       tml-jobs: ${{ steps.treadmill-job-launch.outputs.tml-jobs }}
-
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-
       - name: Checkout Treadmill repository
         uses: actions/checkout@v4
         with:
@@ -82,51 +72,43 @@ jobs:
           # treadmill-tb/treadmill main as of Oct 1, 2024, 3:05 PM EDT
           ref: 'c82f4d7ebddd17f8275ba52139e64e04623f30cb'
           path: treadmill
-
       - name: Cache Treadmill CLI compilation artifacts
         id: cache-tml-cli
         uses: actions/cache@v4
         with:
           path: treadmill/target
           key: ${{ runner.os }}-tml-cli
-
       - name: Compile the Treadmill CLI binary
         run: |
           pushd treadmill
           cargo build --package tml-cli
           popd
           echo "$PWD/treadmill/target/debug" >> "$GITHUB_PATH"
-
       - name: Generate a token to register new just-in-time runners
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.TREADMILL_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.TREADMILL_GH_APP_PRIVATE_KEY }}
-
       - name: Create GitHub just-in-time runners and enqueue Treadmill jobs
         id: treadmill-job-launch
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           TML_API_TOKEN: ${{ secrets.TREADMILL_API_TOKEN }}
-
           # Currently, all tests run only on hosts attached to an nRF52840DK
           DUT_BOARD: nrf52840dk
-
           # A Raspberry Pi OS netboot (NBD) image with a GitHub Actions
           # self-hosted runner pre-configured.
           #
           # For the available images see
           # https://book.treadmill.ci/treadmillci-deployment/images.html
           IMAGE_ID: f94b8f8edd54321e6370d898f87ccbd2659a67ed0300fda2adc8099cdd157790
-
           # Limit the supervisors to hosts that are compatible with this
           # image. This is a hack until we introduce "image sets" which define
           # multiple images for various supervisor hosts, but otherwise behave
           # identically:
           HOST_TYPE: nbd-netboot
           HOST_ARCH: arm64
-
           TESTS_JSON: ${{ inputs.tests-json }}
           # Support for specific supervisor targeting for multi-board tests
           MULTI_BOARD: ${{ inputs.multi-board }}
@@ -168,7 +150,7 @@ jobs:
           }"
 
           echo "Enqueueing treadmill job:"
-          
+
           # If this is a multi-board test targeting a specific supervisor
           if [ "$MULTI_BOARD" = "true" ] && [ -n "$SUPERVISOR_ID" ]; then
             TML_JOB_ID_JSON="$(tml job enqueue \
@@ -212,7 +194,6 @@ jobs:
             fi
             echo "| \`$TEST\` | \`$BOARD_INFO\` | [\`$TML_JOB_ID\`](#tml-job-summary-$TML_JOB_ID) |" >>"$GITHUB_STEP_SUMMARY"
           done
-
   test-execute:
     needs: test-prepare
     strategy:
@@ -238,16 +219,13 @@ jobs:
           ls -lh /dev/ttyACM* 2>/dev/null || true
           ls -lh /dev/ttyUSB* 2>/dev/null || true
           ls -lh /dev/bus/usb/*/* 2>/dev/null || true
-
       - name: Disable wget progress output
         run: |
           echo "verbose = off" >> $HOME/.wgetrc
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           # Avoid overwriting the RUSTFLAGS environment variable
           rustflags: ''
-
       # This is required for the actions/checkout steps to perform a
       # proper git clone that also supports checking out submodules:
       - name: Install git
@@ -259,20 +237,17 @@ jobs:
           # part out.
           sudo DEBIAN_FRONTEND=noninteractive apt update || true
           sudo DEBIAN_FRONTEND=noninteractive apt install -y git
-
       - name: Checkout the Tock Hardware CI scripts
         uses: actions/checkout@v4
         with:
           repository: tock/tock-hardware-ci
           ref: ${{ inputs.tock-hardware-ci-ref }}
-
       - name: Checkout the Tock kernel repository
         uses: actions/checkout@v4
         with:
           path: hwci/repos/tock
           repository: tock/tock
           ref: ${{ inputs.tock-kernel-ref }}
-
       - name: Checkout the libtock-c repository
         uses: actions/checkout@v4
         with:
@@ -282,12 +257,10 @@ jobs:
           fetch-depth: 0
           submodules: false
           persist-credentials: true
-
       - name: Run setup script
         run: |
           cd ./hwci/
           ./setup.sh
-
       - name: Run tests
         env:
           JSON_TEST_ARRAY: ${{ toJSON(fromJSON(needs.test-prepare.outputs.tml-jobs)[matrix.tml-job-id].tests) }}
@@ -340,6 +313,9 @@ jobs:
               BOARD_DESC_ARGS+=" --board-descriptors $DESC"
             done
 
+            echo 'python3 hwci/core/main.py $BOARD_DESC_ARGS --test "$TEST"'
+            pwd
+
             # Run test with multiple board descriptors
             python3 hwci/core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
 
@@ -382,11 +358,9 @@ jobs:
             echo "At least one test failed, exiting with error."
             exit 1
           fi
-
       - name: Request shutdown after successful job completion
         run: |
           sudo touch /run/github-actions-shutdown
-
       - name: Provide connection information on job failure
         if: failure()
         run: |

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -273,7 +273,11 @@ jobs:
           ls
           source ./.venv/bin/activate
           cd ..
-          ls
+
+          git clone https://github.com/treadmill-tb/tockloader.git
+          cd tockloader
+          pip install -e .
+          cd ..
 
           STEP_FAIL=0
 
@@ -310,7 +314,7 @@ jobs:
             echo "Running multi-board test with specified board descriptors"
             BOARD_DESC_ARGS=""
             for DESC in $BOARD_DESCRIPTORS; do
-              BOARD_DESC_ARGS+=" --board-descriptors $DESC"
+              BOARD_DESC_ARGS+=" --board-descriptors ../$DESC"
             done
 
             echo "python3 hwci/core/main.py $BOARD_DESC_ARGS --test \"$TEST\""

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -339,10 +339,10 @@ jobs:
             done
 
             # Run test with multiple board descriptors
-            python3 core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+            python3 hwcl/core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
           else
             # Run standard single-board test
-            python3 core/main.py --board boards/nrf52dk.py --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+            python3 hwci/core/main.py --board boards/nrf52dk.py --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
           fi
 
           set +o pipefail

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -297,8 +297,10 @@ jobs:
         run: |
           # MODIFY BEFORE merge vvvvv
           cd ./hwci
+          ls
           source ./.venv/bin/activate
           cd ..
+          ls
 
           STEP_FAIL=0
 

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -45,6 +45,19 @@ on:
         required: false
         type: string
         default: '["tests/c_hello.py"]' # Default to single test for backward compatibility
+      # New inputs for multi-board tests
+      multi-board:
+        required: false
+        type: string
+        default: 'false'
+      supervisor-id:
+        required: false
+        type: string
+        default: ''
+      board-descriptors:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   test-prepare:
@@ -115,6 +128,9 @@ jobs:
           HOST_ARCH: arm64
 
           TESTS_JSON: ${{ inputs.tests-json }}
+          # Support for specific supervisor targeting for multi-board tests
+          MULTI_BOARD: ${{ inputs.multi-board }}
+          SUPERVISOR_ID: ${{ inputs.supervisor-id }}
         run: |
           # When we eventually launch tests on multiple hardware platforms in
           # parallel, we need to supply different SUB_TEST_IDs here:
@@ -152,11 +168,22 @@ jobs:
           }"
 
           echo "Enqueueing treadmill job:"
-          TML_JOB_ID_JSON="$(tml job enqueue \
-            "$IMAGE_ID" \
-            --tag-config "board:$DUT_BOARD;host-type:$HOST_TYPE;host-arch:$HOST_ARCH" \
-            --parameters "$TML_JOB_PARAMETERS" \
-          )"
+          
+          # If this is a multi-board test targeting a specific supervisor
+          if [ "$MULTI_BOARD" = "true" ] && [ -n "$SUPERVISOR_ID" ]; then
+            TML_JOB_ID_JSON="$(tml job enqueue \
+              "$IMAGE_ID" \
+              --tag-config "supervisor:$SUPERVISOR_ID;host-type:$HOST_TYPE;host-arch:$HOST_ARCH" \
+              --parameters "$TML_JOB_PARAMETERS" \
+            )"
+          else
+            # Default job enqueue for single board tests
+            TML_JOB_ID_JSON="$(tml job enqueue \
+              "$IMAGE_ID" \
+              --tag-config "board:$DUT_BOARD;host-type:$HOST_TYPE;host-arch:$HOST_ARCH" \
+              --parameters "$TML_JOB_PARAMETERS" \
+            )"
+          fi
 
           TML_JOB_ID="$(echo "$TML_JOB_ID_JSON" | jq -r .job_id)"
           echo "Enqueued Treadmill job with ID $TML_JOB_ID"
@@ -179,7 +206,11 @@ jobs:
           |------|-------|-----|
           GITHUB_STEP_SUMMARY
           echo "$TESTS_JSON" | jq -r -c '.[]' | while read TEST; do
-            echo "| \`$TEST\` | \`$DUT_BOARD\` | [\`$TML_JOB_ID\`](#tml-job-summary-$TML_JOB_ID) |" >>"$GITHUB_STEP_SUMMARY"
+            BOARD_INFO="$DUT_BOARD"
+            if [ "$MULTI_BOARD" = "true" ]; then
+              BOARD_INFO="Multiple boards on supervisor $SUPERVISOR_ID"
+            fi
+            echo "| \`$TEST\` | \`$BOARD_INFO\` | [\`$TML_JOB_ID\`](#tml-job-summary-$TML_JOB_ID) |" >>"$GITHUB_STEP_SUMMARY"
           done
 
   test-execute:
@@ -192,7 +223,7 @@ jobs:
       - name: Print Treadmill Job Context and Debug Information
         run: |
           echo "Treadmill job id: ${{ matrix.tml-job-id }}"
-          echo "GitHub Actions Runner ID: ${{ fromJSON(needs.test-prepare.outputs.tml-jobs)[matrix.tml-job-id] }}"
+          echo "GitHub Actions Runner ID: ${{ fromJSON(needs.test-prepare.outputs.tml-jobs)[matrix.tml-job-id].runner-id }}"
           echo "===== Parameters: ====="
           ls /run/tml/parameters
           echo "===== User & group configuration: ====="
@@ -259,6 +290,9 @@ jobs:
       - name: Run tests
         env:
           JSON_TEST_ARRAY: ${{ toJSON(fromJSON(needs.test-prepare.outputs.tml-jobs)[matrix.tml-job-id].tests) }}
+          MULTI_BOARD: ${{ inputs.multi-board }}
+          SUPERVISOR_ID: ${{ inputs.supervisor-id }}
+          BOARD_DESCRIPTORS: ${{ inputs.board-descriptors }}
         run: |
           cd ./hwci
           source ./.venv/bin/activate
@@ -267,7 +301,7 @@ jobs:
 
           # Generate a summary of all the tests executed:
           cat <<GITHUB_STEP_SUMMARY >>"$GITHUB_STEP_SUMMARY"
-          ### <a id="tml-job-summary-${{ matrix.tml-job-id }}"></a>Tests executed on board \`nrf52840dk\`, job ID ${{ matrix.tml-job-id }}
+          ### <a id="tml-job-summary-${{ matrix.tml-job-id }}"></a>Tests executed on job ID ${{ matrix.tml-job-id }}
 
           | Result | Test |
           |--------|------|
@@ -292,7 +326,22 @@ jobs:
           echo "===== RUNNING TEST $TEST ====="
           FAIL=0
           set -o pipefail
-          python3 core/main.py --board boards/nrf52dk.py --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+
+          # Check if this is a multi-board test with specific board descriptors
+          if [ "$MULTI_BOARD" = "true" ] && [ -n "$BOARD_DESCRIPTORS" ]; then
+            echo "Running multi-board test with specified board descriptors"
+            BOARD_DESC_ARGS=""
+            for DESC in $BOARD_DESCRIPTORS; do
+              BOARD_DESC_ARGS+=" --board-descriptors $DESC"
+            done
+
+            # Run test with multiple board descriptors
+            python3 core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+          else
+            # Run standard single-board test
+            python3 core/main.py --board boards/nrf52dk.py --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+          fi
+
           set +o pipefail
 
           # Insert the result into the markdown table:

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -312,9 +312,9 @@ jobs:
           # Check if this is a multi-board test with specific board descriptors
           if [ "$MULTI_BOARD" = "true" ] && [ -n "$BOARD_DESCRIPTORS" ]; then
             echo "Running multi-board test with specified board descriptors"
-            BOARD_DESC_ARGS=""
+            BOARD_DESC_ARGS="--board-descriptors"
             for DESC in $BOARD_DESCRIPTORS; do
-              BOARD_DESC_ARGS+=" --board-descriptors $DESC"
+              BOARD_DESC_ARGS+=" $DESC"
             done
 
             pwd

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -295,8 +295,10 @@ jobs:
           SUPERVISOR_ID: ${{ inputs.supervisor-id }}
           BOARD_DESCRIPTORS: ${{ inputs.board-descriptors }}
         run: |
+          # MODIFY BEFORE merge vvvvv
           cd ./hwci
           source ./.venv/bin/activate
+          cd ..
 
           STEP_FAIL=0
 

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -313,7 +313,7 @@ jobs:
               BOARD_DESC_ARGS+=" --board-descriptors $DESC"
             done
 
-            echo 'python3 hwci/core/main.py $BOARD_DESC_ARGS --test "$TEST"'
+            echo "python3 hwci/core/main.py $BOARD_DESC_ARGS --test \"$TEST\""
             pwd
 
             # Run test with multiple board descriptors

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -318,6 +318,10 @@ jobs:
             done
 
             pwd
+            python3 hwci/core/main.py \
+
+
+            echo "python3 hwci/core/main.py $BOARD_DESC_ARGS --test hwci/$TEST 2>&1 | tee ./job-output.txt || FAIL=1"
 
             # Run test with multiple board descriptors
             python3 hwci/core/main.py $BOARD_DESC_ARGS --test "hwci/$TEST" 2>&1 | tee ./job-output.txt || FAIL=1

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -341,7 +341,8 @@ jobs:
             done
 
             # Run test with multiple board descriptors
-            python3 hwcl/core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+            python3 hwci/core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+
           else
             # Run standard single-board test
             python3 hwci/core/main.py --board boards/nrf52dk.py --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -318,8 +318,6 @@ jobs:
             done
 
             pwd
-            python3 hwci/core/main.py \
-
 
             echo "python3 hwci/core/main.py $BOARD_DESC_ARGS --test hwci/$TEST 2>&1 | tee ./job-output.txt || FAIL=1"
 

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -279,8 +279,6 @@ jobs:
           pip install -e .
           cd ..
 
-          cd ./hwci
-
           STEP_FAIL=0
 
           # Generate a summary of all the tests executed:
@@ -316,18 +314,17 @@ jobs:
             echo "Running multi-board test with specified board descriptors"
             BOARD_DESC_ARGS=""
             for DESC in $BOARD_DESCRIPTORS; do
-              BOARD_DESC_ARGS+=" --board-descriptors ../$DESC"
+              BOARD_DESC_ARGS+=" --board-descriptors $DESC"
             done
 
-            echo "python3 hwci/core/main.py $BOARD_DESC_ARGS --test \"$TEST\""
             pwd
 
             # Run test with multiple board descriptors
-            python3 core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+            python3 hwci/core/main.py $BOARD_DESC_ARGS --test "hwci/$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
 
           else
             # Run standard single-board test
-            python3 hwci/core/main.py --board boards/nrf52dk.py --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+            python3 hwci/core/main.py --board hwci/boards/nrf52dk.py --test "hwci/$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
           fi
 
           set +o pipefail

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -274,11 +274,6 @@ jobs:
           source ./.venv/bin/activate
           cd ..
 
-          git clone https://github.com/treadmill-tb/tockloader.git
-          cd tockloader
-          pip install -e .
-          cd ..
-
           STEP_FAIL=0
 
           # Generate a summary of all the tests executed:

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -279,6 +279,8 @@ jobs:
           pip install -e .
           cd ..
 
+          cd ./hwci
+
           STEP_FAIL=0
 
           # Generate a summary of all the tests executed:
@@ -321,7 +323,7 @@ jobs:
             pwd
 
             # Run test with multiple board descriptors
-            python3 hwci/core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
+            python3 core/main.py $BOARD_DESC_ARGS --test "$TEST" 2>&1 | tee ./job-output.txt || FAIL=1
 
           else
             # Run standard single-board test

--- a/board_descriptors/0679be07-6106-48aa-8057-b1d4f2e18a99/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/0679be07-6106-48aa-8057-b1d4f2e18a99/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '0679be07-6106-48aa-8057-b1d4f2e18a99'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: true
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/0af84b36-1d44-4e0e-9046-1f3fd8ec1cbf/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/0af84b36-1d44-4e0e-9046-1f3fd8ec1cbf/board-nrf52840dk-SERIAL.yml
@@ -1,5 +1,5 @@
 model: nrf52840dk
-serial_number: '0af84b36-1d44-4e0e-9046-1f3fd8ec1cbf'
+serial_number: ''
 board_module: boards/nrf52dk.py
 host_type: QEMU
 features:

--- a/board_descriptors/0af84b36-1d44-4e0e-9046-1f3fd8ec1cbf/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/0af84b36-1d44-4e0e-9046-1f3fd8ec1cbf/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,8 @@
+model: nrf52840dk
+serial_number: '0af84b36-1d44-4e0e-9046-1f3fd8ec1cbf'
+board_module: boards/nrf52dk.py
+host_type: QEMU
+features:
+  ble: true
+  debugger: jlink
+  gpio: false

--- a/board_descriptors/1bdc10a7-9bea-4da5-9e9c-02c046223dfb/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/1bdc10a7-9bea-4da5-9e9c-02c046223dfb/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,8 @@
+model: nrf52840dk
+serial_number: '1bdc10a7-9bea-4da5-9e9c-02c046223dfb'
+board_module: hwci/boards/nrf52dk.py
+host_type: QEMU
+features:
+  ble: true
+  debugger: jlink
+  gpio: false

--- a/board_descriptors/25b97cf7-cf3c-4955-8f33-a8ea938c4f5b/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/25b97cf7-cf3c-4955-8f33-a8ea938c4f5b/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,8 @@
+model: nrf52840dk
+serial_number: '25b97cf7-cf3c-4955-8f33-a8ea938c4f5b'
+board_module: hwci/boards/nrf52dk.py
+host_type: QEMU
+features:
+  ble: true
+  debugger: jlink
+  gpio: false

--- a/board_descriptors/524aa422-3ea7-47be-99d3-b78430449589/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/524aa422-3ea7-47be-99d3-b78430449589/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '524aa422-3ea7-47be-99d3-b78430449589'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: true
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/56f98833-da16-4ba0-9f38-2b02cfd01ddd/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/56f98833-da16-4ba0-9f38-2b02cfd01ddd/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '56f98833-da16-4ba0-9f38-2b02cfd01ddd'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: true
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/64e5e94d-67e9-4276-9a0c-509a6789b372/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/64e5e94d-67e9-4276-9a0c-509a6789b372/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '64e5e94d-67e9-4276-9a0c-509a6789b372'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: true
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/8723bd6d-88d4-4605-94f1-331b8d54a202/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/8723bd6d-88d4-4605-94f1-331b8d54a202/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '8723bd6d-88d4-4605-94f1-331b8d54a202'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: true
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/8ff22e8e-ead7-433a-a921-c7206face09d/board-nrf52840dk-SERIAL.yml
+++ b/board_descriptors/8ff22e8e-ead7-433a-a921-c7206face09d/board-nrf52840dk-SERIAL.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '8ff22e8e-ead7-433a-a921-c7206face09d'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: true
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml
+++ b/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '1050202501'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: false
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
+++ b/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '1050244773'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: false
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050289195.yml
+++ b/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050289195.yml
@@ -1,6 +1,10 @@
 model: nrf52840dk
-hw_rev: '3.2'
-serial_number: 0xfoobar
+serial_number: '1050289195'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: false
 pin_mappings:
   P0.13:
     io_interface: raspberrypi5gpio
@@ -26,11 +30,3 @@ pin_mappings:
     target_pin_function: BUTTON2
     target_pin_mode: input
     target_pin_active: low
-  P1.01:
-    io_interface: raspberrypi5gpio
-    io_pin_spec: 16
-    target_pin_function: GPIO0
-  P1.02:
-    io_interface: raspberrypi5gpio
-    io_pin_spec: 13
-    target_pin_function: GPIO1

--- a/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050292283.yml
+++ b/board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050292283.yml
@@ -1,0 +1,32 @@
+model: nrf52840dk
+serial_number: '1050292283'
+board_module: hwci/boards/nrf52dk.py
+features:
+  ble: true
+  debugger: jlink
+  gpio: false
+pin_mappings:
+  P0.13:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 20
+    target_pin_function: LED1
+    target_pin_mode: output
+    target_pin_active: low
+  P0.14:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 19
+    target_pin_function: LED2
+    target_pin_mode: output
+    target_pin_active: low
+  P0.11:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 21
+    target_pin_function: BUTTON1
+    target_pin_mode: input
+    target_pin_active: low
+  P0.12:
+    io_interface: raspberrypi5gpio
+    io_pin_spec: 26
+    target_pin_function: BUTTON2
+    target_pin_mode: input
+    target_pin_active: low

--- a/hwci/boards/nrf52dk.py
+++ b/hwci/boards/nrf52dk.py
@@ -38,6 +38,7 @@ class Nrf52dk(TockloaderBoard):
     def get_uart_port(self):
         logging.info("Getting list of serial ports")
         ports = list(serial.tools.list_ports.comports())
+        print(ports)
 
         # First, check if we have a serial_number to match
         board_serial = getattr(self, "serial_number", None)
@@ -70,6 +71,7 @@ class Nrf52dk(TockloaderBoard):
         # If no serial number is provided or we couldn't find a match,
         # just return the first J-Link port for now (this will be replaced later)
         jlink_ports = [p for p in ports if "J-Link" in p.description]
+
         if jlink_ports:
             selected_port = jlink_ports[0].device
             logging.info(

--- a/hwci/boards/nrf52dk.py
+++ b/hwci/boards/nrf52dk.py
@@ -10,41 +10,98 @@ import serial.tools.list_ports
 from boards.tockloader_board import TockloaderBoard
 from utils.serial_port import SerialPort
 from gpio.gpio import GPIO
-import yaml
-import os
 
 
 class Nrf52dk(TockloaderBoard):
     def __init__(self):
         super().__init__()
         self.arch = "cortex-m4"
-        self.kernel_path = os.path.join(
-            self.base_dir, "repos/tock")
+
+        # Path to Tock's root directory
+        self.kernel_path = os.path.join(self.base_dir, "repos", "tock")
+
+        # Path to the nrf52840dk board folder in Tock
         self.kernel_board_path = os.path.join(
-            self.kernel_path, "boards/nordic/nrf52840dk")
+            self.kernel_path, "boards", "nordic", "nrf52840dk"
+        )
+
         self.uart_port = self.get_uart_port()
         self.uart_baudrate = self.get_uart_baudrate()
-        self.openocd_board = "nrf52dk"
+
+        # Tockloader board info
+        self.openocd_board = "nrf52dk"  # Matches `--board nrf52dk` in Tockloader
         self.board = "nrf52dk"
+
         self.serial = self.get_serial_port()
         self.gpio = self.get_gpio_interface()
 
     def get_uart_port(self):
         logging.info("Getting list of serial ports")
         ports = list(serial.tools.list_ports.comports())
-        for port in ports:
-            if "J-Link" in port.description:
-                logging.info(f"Found J-Link port: {port.device}")
-                return port.device
+
+        # First, check if we have a serial_number to match
+        board_serial = getattr(self, "serial_number", None)
+        if board_serial:
+            logging.info(f"Looking for serial port with J-Link SN: {board_serial}")
+
+            # Find ports that match our serial number
+            matching_ports = []
+            for port in ports:
+                # Check if our serial number is in the port's serial_number or hwid
+                if (
+                    hasattr(port, "serial_number")
+                    and board_serial == port.serial_number
+                ):
+                    matching_ports.append(port)
+                elif hasattr(port, "hwid") and board_serial in port.hwid:
+                    matching_ports.append(port)
+
+            # Sort matching ports by device name to pick the lower-numbered one
+            if matching_ports:
+                matching_ports.sort(key=lambda p: p.device)
+                selected_port = matching_ports[0].device
+                logging.info(
+                    f"Found matching J-Link port for SN {board_serial}: {selected_port}"
+                )
+                return selected_port
+
+            logging.warning(f"No serial port found matching J-Link SN: {board_serial}")
+
+        # If no serial number is provided or we couldn't find a match,
+        # just return the first J-Link port for now (this will be replaced later)
+        jlink_ports = [p for p in ports if "J-Link" in p.description]
+        if jlink_ports:
+            selected_port = jlink_ports[0].device
+            logging.info(
+                f"No serial number provided or match found. Using first J-Link port: {selected_port}"
+            )
+            return selected_port
+
+        # If no J-Link ports were found at all
         if ports:
-            logging.info(f"Automatically selected port: {ports[0].device}")
+            logging.warning(
+                f"No J-Link ports found. Using first available port: {ports[0].device}"
+            )
             return ports[0].device
-        else:
-            logging.error("No serial ports found")
-            raise Exception("No serial ports found")
+
+        logging.error("No serial ports found")
+        raise Exception("No serial ports found")
+
+    def update_serial_port(self):
+        """Update the serial port based on the current serial_number attribute."""
+        if hasattr(self, "serial_number") and self.serial_number:
+            old_port = self.uart_port
+            self.uart_port = self.get_uart_port()
+            if old_port != self.uart_port:
+                logging.info(f"Updated serial port from {old_port} to {self.uart_port}")
+                # Close the old serial port if it exists
+                if self.serial:
+                    self.serial.close()
+                # Create a new serial port object
+                self.serial = self.get_serial_port()
 
     def get_uart_baudrate(self):
-        return 115200  # Default baudrate for the board
+        return 115200
 
     def get_serial_port(self):
         logging.info(
@@ -53,11 +110,15 @@ class Nrf52dk(TockloaderBoard):
         return SerialPort(self.uart_port, self.uart_baudrate)
 
     def get_gpio_interface(self):
-        # Load the target spec from a YAML file
-        target_spec = load_target_spec()
-        # Initialize GPIO with the target spec
-        gpio = GPIO(target_spec)
-        return gpio
+        # If there is no 'pin_mappings' attribute, skip GPIO config
+        if not hasattr(self, "pin_mappings"):
+            logging.info(
+                "No pin_mappings found in board descriptor; skipping GPIO init."
+            )
+            return None
+
+        target_spec = {"pin_mappings": self.pin_mappings}
+        return GPIO(target_spec)
 
     def cleanup(self):
         if self.gpio:
@@ -67,54 +128,188 @@ class Nrf52dk(TockloaderBoard):
             self.serial.close()
 
     def flash_kernel(self):
+        """
+        Flash the Tock OS kernel using tockloader directly with correct board config.
+        """
         logging.info("Flashing the Tock OS kernel")
         if not os.path.exists(self.kernel_path):
-            logging.error(f"Tock directory {self.kernel_path} not found")
             raise FileNotFoundError(f"Tock directory {self.kernel_path} not found")
 
-        # Run make flash-openocd from the board directory
+        # Make sure the kernel is built and ready
         subprocess.run(
-            ["make", "flash-openocd"], cwd=self.kernel_board_path, check=True
+            ["make"],
+            cwd=self.kernel_board_path,
+            check=True,
+        )
+
+        # Path to the kernel binary
+        kernel_bin = os.path.join(
+            self.kernel_path, "target/thumbv7em-none-eabi/release/nrf52840dk.bin"
+        )
+
+        # Get the serial number of this board
+        serial_number = getattr(self, "serial_number", None)
+        if not serial_number:
+            logging.warning(
+                "No serial number specified for board. Using first available board."
+            )
+
+        # Build the tockloader command with the correct order of arguments
+        tockloader_cmd = ["tockloader", "flash"]
+
+        # Order matters! These flags must come AFTER the 'flash' command
+        if serial_number:
+            tockloader_cmd.extend(["--openocd-serial-number", serial_number])
+
+        # Add the rest of the arguments
+        tockloader_cmd.extend(
+            [
+                "--openocd",
+                "--openocd-board",
+                "nordic_nrf52_dk.cfg",
+                "--address",
+                "0x00000",
+                "--board",
+                "nrf52dk",
+                kernel_bin,
+            ]
+        )
+
+        # Run the tockloader command
+        logging.info(f"Running tockloader command: {' '.join(tockloader_cmd)}")
+        subprocess.run(
+            tockloader_cmd,
+            check=True,
         )
 
     def erase_board(self):
+        """
+        Issue an nrf52_recover over SWD, specifying 'adapter serial <SN>' if available.
+        This uses OpenOCD directly to mass erase/unlock the chip.
+        """
         logging.info("Erasing the board")
-        command = [
-            "openocd",
-            "-c",
-            "adapter driver jlink; transport select swd; source [find target/nrf52.cfg]; init; nrf52_recover; exit",
-        ]
+        jlink_serial = getattr(self, "serial_number", None)
+
+        if jlink_serial:
+            cmd_string = (
+                f"adapter driver jlink; transport select swd; source [find target/nrf52.cfg]; "
+                f"adapter serial {jlink_serial}; "
+                "init; nrf52_recover; exit"
+            )
+        else:
+            cmd_string = (
+                "adapter driver jlink; transport select swd; source [find target/nrf52.cfg]; "
+                "init; nrf52_recover; exit"
+            )
+
+        command = ["openocd", "-c", cmd_string]
+        logging.info(f"Running OpenOCD command: {command}")
         subprocess.run(command, check=True)
 
     def reset(self):
-        logging.info("Performing a target reset via JTAG")
-        command = [
-            "openocd",
-            "-c",
-            "adapter driver jlink; transport select swd; source [find target/nrf52.cfg]; init; reset; exit",
-        ]
+        """
+        Hard reset the board using OpenOCD, specifying the J-Link serial if we have one.
+        """
+        logging.info("Performing a target reset via JTAG/SWD")
+        jlink_serial = getattr(self, "serial_number", None)
+
+        if jlink_serial:
+            cmd_string = (
+                f"adapter driver jlink; transport select swd; source [find target/nrf52.cfg]; "
+                f"adapter serial {jlink_serial}; "
+                "init; reset; exit"
+            )
+        else:
+            cmd_string = (
+                "adapter driver jlink; transport select swd; source [find target/nrf52.cfg]; "
+                "init; reset; exit"
+            )
+
+        command = ["openocd", "-c", cmd_string]
+        logging.info(f"Running OpenOCD command: {command}")
         subprocess.run(command, check=True)
 
-    # The flash_app method is inherited from TockloaderBoard
+    def flash_app(self, app):
+        if type(app) == str:
+            app_path = app
+            app_name = os.path.basename(app_path)
+            tab_file = os.path.join("build", f"{app_name}.tab")
+        else:
+            app_path = app["path"]
+            app_name = app["name"]
+            tab_file = app["tab_file"]  # relative to "path"
+
+        logging.info(f"Flashing app: {app_name}")
+        libtock_c_dir = os.path.join(self.base_dir, "repos", "libtock-c")
+        if not os.path.exists(libtock_c_dir):
+            logging.error(f"libtock-c directory {libtock_c_dir} not found")
+            raise FileNotFoundError(f"libtock-c directory {libtock_c_dir} not found")
+
+        app_dir = os.path.join(libtock_c_dir, "examples", app_path)
+        if not os.path.exists(app_dir):
+            logging.error(f"App directory {app_dir} not found")
+            raise FileNotFoundError(f"App directory {app_dir} not found")
+
+        # Build the app using absolute paths
+        logging.info(f"Building app: {app_name}")
+        if app_name != "lua-hello":
+            subprocess.run(
+                ["make", f"TOCK_TARGETS={self.arch}"], cwd=app_dir, check=True
+            )
+        else:
+            # if the app is lua-hello, we need to build the libtock-c submodule first
+            with self.change_directory(libtock_c_dir):
+                subprocess.run(
+                    ["make", f"TOCK_TARGETS={self.arch}"], cwd=app_dir, check=True
+                )
+
+        tab_path = os.path.join(app_dir, tab_file)
+        if not os.path.exists(tab_path):
+            logging.error(f"Tab file {tab_path} not found")
+            raise FileNotFoundError(f"Tab file {tab_path} not found")
+
+        logging.info(f"Installing app: {app_name}")
+
+        # Get the serial number of this board
+        serial_number = getattr(self, "serial_number", None)
+
+        # Build the tockloader command with the correct order of arguments
+        tockloader_cmd = ["tockloader", "install"]
+
+        # Add serial number if available
+        if serial_number:
+            tockloader_cmd.extend(["--openocd-serial-number", serial_number])
+
+        # Add the rest of the arguments
+        tockloader_cmd.extend(
+            [
+                "--openocd",
+                "--openocd-board",
+                "nordic_nrf52_dk.cfg",
+                "--board",
+                self.board,
+                tab_path,
+            ]
+        )
+
+        # Run the tockloader command
+        logging.info(f"Running tockloader command: {' '.join(tockloader_cmd)}")
+        subprocess.run(
+            tockloader_cmd,
+            check=True,
+        )
 
     @contextmanager
     def change_directory(self, new_dir):
-        previous_dir = os.getcwd()
+        old_dir = os.getcwd()
         os.chdir(new_dir)
         logging.info(f"Changed directory to: {os.getcwd()}")
         try:
             yield
         finally:
-            os.chdir(previous_dir)
+            os.chdir(old_dir)
             logging.info(f"Reverted to directory: {os.getcwd()}")
 
 
-def load_target_spec():
-    # Assume the target spec file is in a fixed location
-    target_spec_path = os.path.join(os.getcwd(), "target_spec.yaml")
-    with open(target_spec_path, "r") as f:
-        target_spec = yaml.safe_load(f)
-    return target_spec
-
-
+# Global board object used by the test harness
 board = Nrf52dk()

--- a/hwci/core/main.py
+++ b/hwci/core/main.py
@@ -44,14 +44,22 @@ def main():
         )
         sys.exit(1)
 
+    logging.info(f"Loading {len(args.board_descriptors)} board descriptors")
+    logging.info(f"Loading test module: {args.test}")
+    logging.info(f"Python path: {sys.path}")
+    logging.info(f"Board descriptors: {args.board_descriptors}")
+
     for descriptor_path in args.board_descriptors:
         logging.info(f"Loading board descriptor: {descriptor_path}")
         with open(descriptor_path, "r") as f:
-            board_info = yaml.safe_load(f)
+            yaml_content = f.read()
+            # Log the raw YAML content
+            logging.info(f"YAML content:\n{yaml_content}")
+            # Parse the YAML
+            board_info = yaml.safe_load(yaml_content)
+        
         if not board_info:
-            logging.error(
-                f"Board descriptor file {descriptor_path} is empty or invalid."
-            )
+            logging.error(f"Board descriptor file {descriptor_path} is empty or invalid.")
             sys.exit(1)
 
         # We expect something like: board_module: boards/nrf52dk.py

--- a/hwci/core/main.py
+++ b/hwci/core/main.py
@@ -6,11 +6,24 @@ import argparse
 import logging
 import importlib.util
 import sys
+import os
+import yaml
 from pathlib import Path
+
+#  python3 hwci/core/main.py \
+#   --board-descriptors \
+#     board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050202501.yml \
+#     board_descriptors/fb1384d5-e1a5-469c-beb4-0d4d215c9793/board-nrf52840dk-001050244773.yml \
+#   --test hwci/tests/ble_advertising_scanning_test.py
+
 
 def main():
     parser = argparse.ArgumentParser(description="Run tests on Tock OS")
-    parser.add_argument("--board", required=True, help="Path to the board module")
+    parser.add_argument(
+        "--board-descriptors",
+        nargs="+",
+        help="Paths to YAML board descriptor files (e.g. board-descriptors/.../*.yml).",
+    )
     parser.add_argument("--test", required=True, help="Path to the test module")
     args = parser.parse_args()
 
@@ -20,39 +33,84 @@ def main():
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
-    # Ensure that imported modules can find the top-level hwci modules
-    # (appends the hwci root to the PYTHONPATH):
+    # Ensure that Python can find 'hwci' modules
     sys.path.append(str(Path(__file__).parent.parent))
 
-    # 1. Load board module
-    board_spec = importlib.util.spec_from_file_location("board_module", args.board)
-    board_module = importlib.util.module_from_spec(board_spec)
-    board_spec.loader.exec_module(board_module)
-    if hasattr(board_module, "board"):
-        board = board_module.board
-    else:
-        logging.error("No board class found in the specified board module")
+    # 1. Parse each board descriptor
+    boards = []
+    if not args.board_descriptors:
+        logging.error(
+            "No board descriptors were provided. Use --board-descriptors *.yml"
+        )
         sys.exit(1)
 
-    # 5. Load test module, run test function
-    test_spec = importlib.util.spec_from_file_location("test_module", args.test)
+    for descriptor_path in args.board_descriptors:
+        logging.info(f"Loading board descriptor: {descriptor_path}")
+        with open(descriptor_path, "r") as f:
+            board_info = yaml.safe_load(f)
+        if not board_info:
+            logging.error(
+                f"Board descriptor file {descriptor_path} is empty or invalid."
+            )
+            sys.exit(1)
+
+        # We expect something like: board_module: boards/nrf52dk.py
+        board_module_path = board_info.get("board_module")
+        if not board_module_path:
+            logging.error(f"Missing 'board_module' in descriptor {descriptor_path}")
+            sys.exit(1)
+
+        # 2. Import that Python module dynamically
+        if os.path.isfile(board_module_path):
+            # If board_module is an actual file path (e.g. boards/nrf52dk.py)
+            spec = importlib.util.spec_from_file_location(
+                "board_module", board_module_path
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+        else:
+            # Alternatively, if it's a dotted name like "boards.nrf52dk"
+            mod = importlib.import_module(board_module_path)
+
+        # 3. Grab the 'board' object from the module
+        if not hasattr(mod, "board"):
+            logging.error(f"No 'board' object found in {board_module_path}")
+            sys.exit(1)
+
+        board_instance = getattr(mod, "board")
+
+        # Optionally store descriptor metadata on the board instance
+        board_instance.model = board_info.get("model")
+        board_instance.serial_number = board_info.get("serial_number")
+        board_instance.features = board_info.get("features", {})
+        if hasattr(board_instance, "update_serial_port"):
+            board_instance.update_serial_port()
+
+        boards.append(board_instance)
+
+    # 4. Load the test module
+    test_path = args.test
+    test_spec = importlib.util.spec_from_file_location("test_module", test_path)
     test_module = importlib.util.module_from_spec(test_spec)
     test_spec.loader.exec_module(test_module)
-    if hasattr(test_module, "test"):
-        test = test_module.test
-    else:
+
+    if not hasattr(test_module, "test"):
         logging.error("No test variable found in the specified test module")
         sys.exit(1)
 
-    # Run the test
+    test = test_module.test
+
+    # 5. Run the test, passing our list of boards
     try:
-        test.test(board)
-        logging.info("Test completed successfully")
+        test.test(boards)
+        logging.info("Test completed successfully!")
     except Exception as e:
         logging.exception("An error occurred during test execution")
         sys.exit(1)
     finally:
-        board.cleanup()
+        # Cleanup each board
+        for b in boards:
+            b.cleanup()
 
 
 if __name__ == "__main__":

--- a/hwci/core/test_harness.py
+++ b/hwci/core/test_harness.py
@@ -3,6 +3,9 @@
 # Copyright Tock Contributors 2024.
 
 
-class TestHarness:
-    def test(self, board):
+class TestHarness(object):
+    """Base class for all tests. By default it does nothing with the boards."""
+
+    def test(self, boards):
+        """Entry point: a list of BoardHarness objects is passed."""
         pass

--- a/hwci/requirements-frozen.txt
+++ b/hwci/requirements-frozen.txt
@@ -14,3 +14,4 @@ siphash==0.0.1
 toml==0.10.2
 tqdm==4.66.6
 wcwidth==0.2.13
+tockloader==1.14.0

--- a/hwci/requirements-frozen.txt
+++ b/hwci/requirements-frozen.txt
@@ -11,7 +11,6 @@ pycryptodome==3.21.0
 pyserial==3.5
 questionary==2.0.1
 siphash==0.0.1
-tockloader==1.13.0
 toml==0.10.2
 tqdm==4.66.6
 wcwidth==0.2.13

--- a/hwci/requirements.txt
+++ b/hwci/requirements.txt
@@ -7,3 +7,4 @@ pyserial
 pyyaml
 gpiozero
 lgpio
+tockloader

--- a/hwci/requirements.txt
+++ b/hwci/requirements.txt
@@ -4,7 +4,6 @@
 
 pexpect
 pyserial
-tockloader
 pyyaml
 gpiozero
 lgpio

--- a/hwci/setup.sh
+++ b/hwci/setup.sh
@@ -37,7 +37,6 @@ set -e -x
 # of its own build process:
 type rustup || (echo "rustup is not installed, aborting."; exit 1)
 
-# Ensure that `elf2tab` is installed:
 if ! type elf2tab; then
 	# We may not have a rustup default toolchain selected. In this case,
 	# select the stable toolchain for elf2tab.

--- a/hwci/tests/ble_advertising_scanning_test.py
+++ b/hwci/tests/ble_advertising_scanning_test.py
@@ -24,8 +24,10 @@ class BleAdvertisingScanningTest(TestHarness):
     # Configuration constants for test validation
     EXPECTED_DEVICE_NAME = "TockOS"
 
-    # Regular‑expression version so we’re resilient to variable whitespace
-    MANUFACTURER_DATA_RE = re.compile(r"\b13\s+37\b", re.IGNORECASE)
+    # Manufacturer‑specific field starts with 0xFF, followed by our company ID.
+    # The ID {0x13,0x37} is little‑endian on the wire, so the scanner shows
+    # either “ff 13 37” *or* “ff 03 37”.  Accept both and ignore spacing.
+    MANUFACTURER_DATA_RE = re.compile(r"\bff\s+(?:13\s+37|03\s+37)\b", re.IGNORECASE)
 
     def test(self, boards):
         if len(boards) < 2:

--- a/hwci/tests/ble_advertising_scanning_test.py
+++ b/hwci/tests/ble_advertising_scanning_test.py
@@ -167,10 +167,12 @@ class BleAdvertisingScanningTest(TestHarness):
                             device_name_found = True
 
                         # Mark scan as done if we found sufficient evidence this is our advertisement
-                        if (
-                            manufacturer_data_found or device_name_found
-                        ) and "NON_CONNECT_IND" in current_pdu_type:
+                        if manufacturer_data_found or device_name_found:
+                            # Accept any advertisement type for now
                             scan_done = True
+                            logging.info(
+                                f"Found our advertisement data in PDU type: {current_pdu_type}"
+                            )
 
                 # Alternative approach: look for specific patterns in raw output
                 if ("NON_CONNECT_IND" in text_scan) and not scan_done:

--- a/hwci/tests/ble_advertising_scanning_test.py
+++ b/hwci/tests/ble_advertising_scanning_test.py
@@ -28,10 +28,13 @@ class BleAdvertisingScanningTest(TestHarness):
     EXPECTED_DEVICE_NAME = "TockOS"
 
     # Human‑readable form for error messages / logging only
-    MANUFACTURER_DATA = "13 37"
+    # MANUFACTURER_DATA = "13 37"
 
     # Regex that matches either byte order, with flexible whitespace and case
-    MANUFACTURER_DATA_RE = re.compile(r"\bff\s+(?:13\s+37|03\s+37)\b", re.IGNORECASE)
+    # MANUFACTURER_DATA_RE = re.compile(r"\bff\s+(?:13\s+37|03\s+37)\b", re.IGNORECASE)
+
+    MANUFACTURER_DATA = "06 00"
+    MANUFACTURER_DATA_RE = re.compile(r"\bff\s+06\s+00\b", re.IGNORECASE)
 
     def test(self, boards):
         if len(boards) < 2:

--- a/hwci/tests/ble_advertising_scanning_test.py
+++ b/hwci/tests/ble_advertising_scanning_test.py
@@ -1,0 +1,178 @@
+# hwci/tests/ble_advertising_scanning_test.py
+
+import logging
+import time
+import re
+from core.test_harness import TestHarness
+
+
+class BleAdvertisingScanningTest(TestHarness):
+    """
+    Multi-board test:
+    - Board 0: ble_advertising
+    - Board 1: ble_passive_scanning
+
+    We confirm that the advertiser prints "Now advertising..."
+    and that the scanner detects the specific advertisement from our advertiser.
+
+    The test validates:
+    1. The advertiser successfully advertises with the expected device name
+    2. The scanner detects the advertiser's specific advertisement
+    3. The advertisement contains the expected data payload
+    """
+
+    # Configuration constants for test validation
+    EXPECTED_DEVICE_NAME = "TockOS"
+    EXPECTED_PDU_TYPE = "NON_CONNECT_IND"
+    EXPECTED_MANUFACTURER_DATA = (
+        "13 37"  # From the advertiser's manufacturer_data[] = {0x13, 0x37}
+    )
+
+    # Pattern to extract BLE address from log output
+    ADDR_PATTERN = r"Address: ([0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2})"
+
+    # Pattern to extract device name from advertisement data
+    DEVICE_NAME_PATTERN = (
+        r"TockOS"  # Simplified pattern - could be enhanced to extract from actual data
+    )
+
+    def test(self, boards):
+        if len(boards) < 2:
+            raise ValueError(
+                "Need at least 2 boards for BLE advertising/scanning test!"
+            )
+
+        advertiser = boards[0]
+        scanner = boards[1]
+
+        # Check that we're not using the same serial port for both boards
+        if advertiser.uart_port == scanner.uart_port:
+            raise ValueError(
+                f"Both boards are using the same serial port: {advertiser.uart_port}. "
+                f"Each board must have a unique serial port. "
+                f"Board 1 SN: {getattr(advertiser, 'serial_number', 'unknown')}, "
+                f"Board 2 SN: {getattr(scanner, 'serial_number', 'unknown')}"
+            )
+
+        # Log the selected ports for debugging
+        logging.info(
+            f"Advertiser (SN: {advertiser.serial_number}) using port: {advertiser.uart_port}"
+        )
+        logging.info(
+            f"Scanner (SN: {scanner.serial_number}) using port: {scanner.uart_port}"
+        )
+
+        # Erase & reflash the kernel on both boards:
+        advertiser.erase_board()
+        scanner.erase_board()
+        advertiser.serial.flush_buffer()
+        scanner.serial.flush_buffer()
+
+        advertiser.flash_kernel()
+        scanner.flash_kernel()
+
+        # Flash user apps:
+        advertiser.flash_app("ble_advertising")
+        scanner.flash_app("ble_passive_scanning")
+
+        logging.info(
+            "Flashed ble_advertising -> board0, ble_passive_scanning -> board1."
+        )
+
+        # We want to see certain lines from each board. We'll read them in a loop:
+        # Because both boards may print interleaved, we'll poll each board's serial.
+        # We'll store flags once we've seen the key lines.
+
+        adv_done = False  # Did we see the "Now advertising every..."
+        scan_done = False  # Did we see scanner output for our specific advertisement?
+
+        # To store information for validation and error reporting
+        advertiser_addr = None  # Will store the advertiser's BLE address if found
+        received_advertisements = []  # Will store all advertisements found by scanner
+
+        start_time = time.time()
+        TIMEOUT = 30  # total seconds to wait
+
+        while True:
+            if time.time() - start_time > TIMEOUT:
+                break
+
+            # Read from advertiser's console if any new line is present
+            line_adv = advertiser.serial.expect(
+                ".+\r?\n", timeout=1, timeout_error=False
+            )
+            if line_adv:
+                text_adv = line_adv.decode("utf-8", errors="replace").strip()
+                logging.debug(f"[Advertiser] {text_adv}")
+
+                # Detect when advertising starts
+                if (
+                    "Now advertising every" in text_adv
+                    and self.EXPECTED_DEVICE_NAME in text_adv
+                ):
+                    adv_done = True
+                    logging.info(
+                        f"Advertiser started advertising as '{self.EXPECTED_DEVICE_NAME}'"
+                    )
+
+            # Read from scanner's console if any new line is present
+            line_scan = scanner.serial.expect(".+\r?\n", timeout=1, timeout_error=False)
+            if line_scan:
+                text_scan = line_scan.decode("utf-8", errors="replace").strip()
+                logging.debug(f"[Scanner] {text_scan}")
+
+                # Store any discovered advertisement for later analysis
+                if self.EXPECTED_PDU_TYPE in text_scan:
+                    received_advertisements.append(text_scan)
+
+                    # See if this advertisement has our expected characteristics
+                    adv_matches = (
+                        # Check for the expected PDU type
+                        self.EXPECTED_PDU_TYPE in text_scan
+                        and
+                        # Check for the manufacturer data
+                        self.EXPECTED_MANUFACTURER_DATA in text_scan
+                    )
+
+                    if adv_matches:
+                        logging.info("Scanner detected our expected advertisement")
+                        scan_done = True
+
+            if adv_done and scan_done:
+                # We have everything we need
+                break
+
+        # Generate detailed error messages if needed
+        error_messages = []
+
+        if not adv_done:
+            error_messages.append(
+                f"Advertiser board never printed \"Now advertising every ... ms as '{self.EXPECTED_DEVICE_NAME}'\"!"
+            )
+
+        if not scan_done:
+            # Build a more detailed error message
+            error_detail = (
+                f"Scanner board never detected the expected advertisement.\n"
+                f"Expected: PDU Type: {self.EXPECTED_PDU_TYPE}, "
+                f"Manufacturer data: {self.EXPECTED_MANUFACTURER_DATA}\n"
+            )
+
+            if received_advertisements:
+                error_detail += "\nReceived advertisements:\n"
+                for i, adv in enumerate(received_advertisements, 1):
+                    # Extract and display just the relevant parts of the advertisement
+                    error_detail += f"- Adv #{i}: {adv[:200]}...\n"
+            else:
+                error_detail += "No advertisements were detected by the scanner!"
+
+            error_messages.append(error_detail)
+
+        # Raise an exception with all error details if there were any failures
+        if error_messages:
+            raise Exception("\n".join(error_messages))
+
+        logging.info("BLE advertising + scanning test passed successfully!")
+
+
+test = BleAdvertisingScanningTest()

--- a/hwci/tests/ble_advertising_scanning_test.py
+++ b/hwci/tests/ble_advertising_scanning_test.py
@@ -2,7 +2,6 @@
 
 import logging
 import time
-import re
 from core.test_harness import TestHarness
 
 
@@ -11,30 +10,9 @@ class BleAdvertisingScanningTest(TestHarness):
     Multi-board test:
     - Board 0: ble_advertising
     - Board 1: ble_passive_scanning
-
     We confirm that the advertiser prints "Now advertising..."
-    and that the scanner detects the specific advertisement from our advertiser.
-
-    The test validates:
-    1. The advertiser successfully advertises with the expected device name
-    2. The scanner detects the advertiser's specific advertisement
-    3. The advertisement contains the expected data payload
+    and that the scanner detects our specific advertisement data.
     """
-
-    # Configuration constants for test validation
-    EXPECTED_DEVICE_NAME = "TockOS"
-    EXPECTED_PDU_TYPE = "NON_CONNECT_IND"
-    EXPECTED_MANUFACTURER_DATA = (
-        "13 37"  # From the advertiser's manufacturer_data[] = {0x13, 0x37}
-    )
-
-    # Pattern to extract BLE address from log output
-    ADDR_PATTERN = r"Address: ([0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2})"
-
-    # Pattern to extract device name from advertisement data
-    DEVICE_NAME_PATTERN = (
-        r"TockOS"  # Simplified pattern - could be enhanced to extract from actual data
-    )
 
     def test(self, boards):
         if len(boards) < 2:
@@ -72,6 +50,8 @@ class BleAdvertisingScanningTest(TestHarness):
         scanner.flash_kernel()
 
         # Flash user apps:
+        #   "ble_advertising" is the path to your ble_advertising directory in libtock-c
+        #   "ble_passive_scanning" is the path to your ble_passive_scanning directory
         advertiser.flash_app("ble_advertising")
         scanner.flash_app("ble_passive_scanning")
 
@@ -84,11 +64,19 @@ class BleAdvertisingScanningTest(TestHarness):
         # We'll store flags once we've seen the key lines.
 
         adv_done = False  # Did we see the "Now advertising every..."
-        scan_done = False  # Did we see scanner output for our specific advertisement?
+        scan_done = False  # Did we see scanner detect our specific advertisement?
 
-        # To store information for validation and error reporting
-        advertiser_addr = None  # Will store the advertiser's BLE address if found
-        received_advertisements = []  # Will store all advertisements found by scanner
+        # Keep track of specific advertisement patterns we're looking for
+        manufacturer_data_found = False  # 0x13, 0x37
+        device_name_found = False  # "TockOS"
+
+        # To track PDU type for the current advertisement being processed
+        current_pdu_type = None
+
+        # For tracking multi-line advertisement data
+        processing_adv_data = False
+        current_address = None
+        current_data = None
 
         start_time = time.time()
         TIMEOUT = 30  # total seconds to wait
@@ -104,16 +92,10 @@ class BleAdvertisingScanningTest(TestHarness):
             if line_adv:
                 text_adv = line_adv.decode("utf-8", errors="replace").strip()
                 logging.debug(f"[Advertiser] {text_adv}")
-
-                # Detect when advertising starts
-                if (
-                    "Now advertising every" in text_adv
-                    and self.EXPECTED_DEVICE_NAME in text_adv
-                ):
+                if "[Tutorial] BLE Advertising" in text_adv:
+                    adv_tutorial_line = True
+                if "Now advertising every" in text_adv:
                     adv_done = True
-                    logging.info(
-                        f"Advertiser started advertising as '{self.EXPECTED_DEVICE_NAME}'"
-                    )
 
             # Read from scanner's console if any new line is present
             line_scan = scanner.serial.expect(".+\r?\n", timeout=1, timeout_error=False)
@@ -121,58 +103,109 @@ class BleAdvertisingScanningTest(TestHarness):
                 text_scan = line_scan.decode("utf-8", errors="replace").strip()
                 logging.debug(f"[Scanner] {text_scan}")
 
-                # Store any discovered advertisement for later analysis
-                if self.EXPECTED_PDU_TYPE in text_scan:
-                    received_advertisements.append(text_scan)
+                # Track beginning and end of advertisement list
+                if (
+                    "--------------------------LIST-------------------------"
+                    in text_scan
+                ):
+                    processing_adv_data = True
+                    continue
 
-                    # See if this advertisement has our expected characteristics
-                    adv_matches = (
-                        # Check for the expected PDU type
-                        self.EXPECTED_PDU_TYPE in text_scan
-                        and
-                        # Check for the manufacturer data
-                        self.EXPECTED_MANUFACTURER_DATA in text_scan
-                    )
+                if (
+                    "--------------------------END---------------------------"
+                    in text_scan
+                ):
+                    processing_adv_data = False
+                    continue
 
-                    if adv_matches:
-                        logging.info("Scanner detected our expected advertisement")
-                        scan_done = True
+                if not processing_adv_data:
+                    # Skip lines outside of an advertisement list
+                    if "[Tutorial] BLE Passive Scanner" in text_scan:
+                        scan_tutorial_line = True
+                    continue
+
+                # Process advertisement data
+                if "PDU Type:" in text_scan:
+                    # Start of a new advertisement
+                    current_pdu_type = text_scan.split("PDU Type:")[1].strip()
+                    # Reset tracking for this advertisement
+                    current_address = None
+                    current_data = None
+
+                elif "Address:" in text_scan:
+                    current_address = text_scan.split("Address:")[1].strip()
+
+                elif "Data:" in text_scan:
+                    current_data = text_scan.split("Data:")[1].strip()
+
+                    # If we have a complete advertisement entry, check it
+                    if current_pdu_type and current_data:
+                        # Reset for next advertisement entry
+                        logging.debug(
+                            f"Checking advertisement - Type: {current_pdu_type}, Data: {current_data}"
+                        )
+
+                        # Look for specific data patterns from our advertiser
+
+                        # Manufacturer data: 0x13, 0x37
+                        # It appears in the data as "ff" (manufacturer data type) followed by "13 37"
+                        if "ff" in current_data and "13 37" in current_data:
+                            logging.info(
+                                "Found manufacturer data (13 37) in advertisement!"
+                            )
+                            manufacturer_data_found = True
+
+                        # Device name: "TockOS"
+                        # It should appear after the device name type code "09"
+                        # ASCII for "TockOS" is: 54 6f 63 6b 4f 53
+                        # But the data may be shortened, so look for parts of it
+                        if "09" in current_data and any(
+                            name_part in current_data
+                            for name_part in ["54 6f 63 6b", "54 6f 63", "54 6f"]
+                        ):
+                            logging.info("Found device name (TockOS) in advertisement!")
+                            device_name_found = True
+
+                        # Mark scan as done if we found sufficient evidence this is our advertisement
+                        if (
+                            manufacturer_data_found or device_name_found
+                        ) and "NON_CONNECT_IND" in current_pdu_type:
+                            scan_done = True
+
+                # Alternative approach: look for specific patterns in raw output
+                if ("NON_CONNECT_IND" in text_scan) and not scan_done:
+                    logging.info("Found NON_CONNECT_IND advertisement, will check data")
 
             if adv_done and scan_done:
                 # We have everything we need
                 break
 
-        # Generate detailed error messages if needed
-        error_messages = []
-
+        # Check if both boards printed the expected lines
         if not adv_done:
-            error_messages.append(
-                f"Advertiser board never printed \"Now advertising every ... ms as '{self.EXPECTED_DEVICE_NAME}'\"!"
+            raise Exception(
+                "Advertiser board never printed \"Now advertising every ... ms as 'TockOS'\"!"
             )
 
+        # Provide a more specific error if we didn't find our advertisement
         if not scan_done:
-            # Build a more detailed error message
-            error_detail = (
-                f"Scanner board never detected the expected advertisement.\n"
-                f"Expected: PDU Type: {self.EXPECTED_PDU_TYPE}, "
-                f"Manufacturer data: {self.EXPECTED_MANUFACTURER_DATA}\n"
-            )
-
-            if received_advertisements:
-                error_detail += "\nReceived advertisements:\n"
-                for i, adv in enumerate(received_advertisements, 1):
-                    # Extract and display just the relevant parts of the advertisement
-                    error_detail += f"- Adv #{i}: {adv[:200]}...\n"
+            error_msg = "Scanner did not detect our specific advertisement data!"
+            if manufacturer_data_found:
+                error_msg += (
+                    " (Found manufacturer data but not in NON_CONNECT_IND type)"
+                )
+            elif device_name_found:
+                error_msg += " (Found device name but not in NON_CONNECT_IND type)"
             else:
-                error_detail += "No advertisements were detected by the scanner!"
-
-            error_messages.append(error_detail)
-
-        # Raise an exception with all error details if there were any failures
-        if error_messages:
-            raise Exception("\n".join(error_messages))
+                error_msg += " No identifying patterns found in any advertisements."
+            raise Exception(error_msg)
 
         logging.info("BLE advertising + scanning test passed successfully!")
+        if manufacturer_data_found:
+            logging.info(
+                "✓ Verified advertisement contained correct manufacturer data (13 37)"
+            )
+        if device_name_found:
+            logging.info("✓ Verified advertisement contained device name (TockOS)")
 
 
 test = BleAdvertisingScanningTest()

--- a/hwci/utils/test_helpers/oneshot.py
+++ b/hwci/utils/test_helpers/oneshot.py
@@ -6,14 +6,22 @@ class OneshotTest(TestHarness):
     def __init__(self, apps=[]):
         self.apps = apps
 
-    def test(self, board):
+    def test(self, boards):
         logging.info("Starting OneshotTest")
-        board.erase_board()
-        board.serial.flush_buffer()
-        board.flash_kernel()
+        if len(boards) != 1:
+            raise ValueError(
+                f"OneshotTest requires exactly 1 board. Got {len(boards)} boards."
+            )
+        single_board = boards[0]
+
+        # Normal single-board flow:
+        single_board.erase_board()
+        single_board.serial.flush_buffer()
+        single_board.flash_kernel()
         for app in self.apps:
-            board.flash_app(app)
-        self.oneshot_test(board)
+            single_board.flash_app(app)
+
+        self.oneshot_test(single_board)
         logging.info("Finished OneshotTest")
 
     def oneshot_test(self, board):


### PR DESCRIPTION
**Pull Request Title:**
Add Multi-Board Treadmill Descriptors & BLE Advertise+Scan Test

**Pull Request Description:**
- **Multi-board support**: Adjust harness to handle multiple boards in a single test run.  
- **Board Descriptors in YAML**: Load boards via `--board-descriptors` instead of `--boards`.  
- **Updated `main.py`**: Dynamically import board modules listed in YAML (e.g. `board-nrf52840dk-<serial>.yml`).  
- **New BLE Test**: Adds `ble_advertising_scanning_test.py` to verify advertiser and scanner boards can detect each other.  

With these changes, `tock-hardware-ci` can run multi-board tests using Treadmill descriptors
