### PR TITLE
tensile: add libtock-rs 15.4 tests

### DIFF
--- a/tensile/.gitignore
+++ b/tensile/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 tensile-venv
 tock
+libtock-rs
 libtock-c
 ot-central-controller.hex

--- a/tensile/board.py
+++ b/tensile/board.py
@@ -66,19 +66,34 @@ class Board:
 
         self.log_info(f"[FLASHING -- COMPLETE] {self.board_serial_no}.") 
 
-        # Build libtock-c app.
-        self.log_info(f"[BUILDING] libtock-c app {self.app_name}...")
-        self.log_info(sh.make("-C", self.libtock_path, _err_to_out=True))
-        self.log_info(f"[BUILDING -- COMPLETE] {self.app_name}.")
+        # Build libtock app.
+        
+        # Building / Flashing is different depending on if libtock-c/rs.
+        if "libtock-rs" in self.libtock_path:
+            self.log_info(f"[BUILDING] libtock-rs app {self.app_name}...")
+            self.log_info(sh.make("-C", "libtock-rs", "nrf52840", f"EXAMPLE={self.app_name}", _err_to_out=True))
+            # Flash libtock app to board.
+            self.log_info(f"[FLASHING] libtock-rs app {self.app_name} to: {self.board_serial_no}...")
+            self.log_info(sh.tockloader(
+                            "install", 
+                            f"libtock-rs/target/nrf52840/thumbv7em-none-eabi/release/examples/{self.app_name}.tab",
+                            "--jlink-serial-number", 
+                            self.board_serial_no, 
+                            _err_to_out=True))
 
-        # Flash libtock-c app to board.
-        self.log_info(f"[FLASHING] libtock-c app {self.app_name} to: {self.board_serial_no}...")
-        self.log_info(sh.tockloader(
-                        "install", 
-                        f"{self.libtock_path}/build/{self.app_name}.tab",
-                        "--jlink-serial-number", 
-                        self.board_serial_no, 
-                        _err_to_out=True))
+        else:
+            self.log_info(f"[BUILDING] libtock-c app {self.app_name}...")
+            self.log_info(sh.make("-C", self.libtock_path, _err_to_out=True))
+
+            # Flash libtock app to board.
+            self.log_info(f"[FLASHING] libtock-c app {self.app_name} to: {self.board_serial_no}...")
+            self.log_info(sh.tockloader(
+                            "install", 
+                            f"{self.libtock_path}/build/{self.app_name}.tab",
+                            "--jlink-serial-number", 
+                            self.board_serial_no, 
+                            _err_to_out=True))
+        
         self.log_info(f"[FLASHING -- COMPLETE] {self.app_name}.")
 
 

--- a/tensile/ieee802154_tests.py
+++ b/tensile/ieee802154_tests.py
@@ -1,6 +1,6 @@
 from board import Board
 
-def radio_rx_test(boards, test_duration_sec=10):
+def libtock_c_radio_rx_test(boards, test_duration_sec=10):
     # We require 2 boards for this test.
     # TODO: Better handling/reporting of case w/o at least 2 boards.
     if len(boards) < 2:
@@ -58,7 +58,7 @@ def radio_rx_test(boards, test_duration_sec=10):
         raise Exception("FAILED: radio_rx test -- {} out of {} packets transmitted successfully. \
                         Dump of received packets:\n {}".format(success_passed, TOTAL_PACKETS, test_rx_results))
 
-def radio_tx_raw_test(boards, test_duration_sec=10):
+def libtock_c_radio_tx_raw_test(boards, test_duration_sec=10):
     # We require 2 boards for this test.
     # TODO: Better handling/reporting of case w/o at least 2 boards.
     if len(boards) < 2:
@@ -115,7 +115,7 @@ def radio_tx_raw_test(boards, test_duration_sec=10):
         raise Exception("FAILED: radio_tx_raw test -- {} out of {} packets transmitted successfully. Dump of \
                 received packets: \n {}".format(success_passed, TOTAL_PACKETS, test_rx_results))
 
-def radio_tx_test(boards, test_duration_sec=10):
+def libtock_c_radio_tx_test(boards, test_duration_sec=10):
     # Create board objects for each device.
     board = Board(boards[0], 
                   "tock/boards/nordic/nrf52840dk", 
@@ -142,3 +142,49 @@ def radio_tx_test(boards, test_duration_sec=10):
         board.log_info("PASSED: radio_tx test")
     else:
         raise Exception("FAILED: radio_tx test -- {} out of {} packets transmitted successfully.".format(success_passed, TOTAL_PACKETS))
+
+
+# Test libtock-rs `ieee802154_tx_raw` and `ieee802154_rx_raw` apps.
+def libtock_rs_radio_raw_test(boards, test_duration_sec=10):
+    # We require 2 boards for this test.
+    # TODO: Better handling/reporting of case w/o at least 2 boards.
+    if len(boards) < 2:
+        raise Exception("Error: [Inadequate resources] - radio_rxtx test requires at least two available boards.")
+    
+    # Create board objects for tx device.
+    board_tx = Board(boards[0], 
+                  "tock/boards/tutorials/nrf52840dk-thread-tutorial", 
+                  "libtock-rs/ieee802154_tx_raw.rs", 
+                  "ieee802154_tx_raw", 
+                  "tock/target/thumbv7em-none-eabi/release/nrf52840dk-thread-tutorial.bin")
+    
+    # Create board object for rx device.
+    board_rx = Board(boards[2], 
+                  "tock/boards/nordic/nrf52840dk", 
+                  "libtock-rs/ieee802154_rx_raw.rs", 
+                  "ieee802154_rx_raw", 
+                  "tock/target/thumbv7em-none-eabi/release/nrf52840dk-thread-tutorial.bin")
+
+    # Setup boards for test.
+    board_tx.prep_test()
+    board_rx.prep_test()
+
+    # Run tests.
+    board_tx.run_test(1)
+    test_rx_results = board_rx.run_test(test_duration_sec)
+
+    # The standard TX test transmits a packet every 1s. 
+    success_passed = 0
+    TOTAL_PACKETS = test_duration_sec 
+
+    index = 0
+    for item in test_rx_results:
+        if "Received frame with body of len 15:" in item:
+            success_passed += 1
+
+    # Check if 50% of packets were transmitted successfully.
+    if success_passed / TOTAL_PACKETS >= 0.50:
+        board_rx.log_info("PASSED: radio_rx test")
+    else:
+        raise Exception("FAILED: radio_rx test -- {} out of {} packets transmitted successfully. \
+                        Dump of received packets:\n {}".format(success_passed, TOTAL_PACKETS, test_rx_results))

--- a/tensile/main.py
+++ b/tensile/main.py
@@ -1,5 +1,5 @@
 from pynrfjprog import LowLevel 
-from ieee802154_tests import radio_tx_test, radio_rx_test, radio_tx_raw_test
+from ieee802154_tests import libtock_c_radio_rx_test, libtock_c_radio_tx_raw_test, libtock_c_radio_tx_test, libtock_rs_radio_raw_test
 from openthread_tests import openthread_hello_test
 
 if __name__ == '__main__':
@@ -9,9 +9,14 @@ if __name__ == '__main__':
     available_devices = nrfjprog_api.enum_emu_snr()
     print(available_devices)
     nrfjprog_api.close()
-    radio_tx_test(available_devices)
-    radio_rx_test(available_devices, 60)
-    radio_tx_raw_test(available_devices, 60)
+
+    # libtock-c tests #
+    libtock_c_radio_tx_test(available_devices)
+    libtock_c_radio_rx_test(available_devices, 60)
+    libtock_c_radio_tx_raw_test(available_devices, 60)
     openthread_hello_test(available_devices)
+
+    # libtock-rs tests #
+    libtock_rs_radio_raw_test(available_devices, 60)
 
     print("===SUCCESSFULLY PASSED ALL TESTS===")

--- a/tensile/setup.sh
+++ b/tensile/setup.sh
@@ -37,15 +37,11 @@ source tensile-venv/bin/activate
 # Install needed python dependencies.
 pip install -r requirements.txt
 
-# NOTE: The testing scripts expect these repos to be in the same directory as main.py.
-# Clone libtock-c / tock / tockloader (need to clone tockloader from my repo temporarily 
-# until the tockloader jlink-selector branch is merged).
-
 if [ ! -f ot-central-controller.hex ]; then
   wget https://book.tockos.org/assets/temperature-sensor/ot-central-controller.hex
 fi
 
 git clone https://github.com/tock/tock.git
 git clone https://github.com/tock/libtock-c.git
-
+git clone https://github.com/tock/libtock-rs.git
 


### PR DESCRIPTION
## Overview

This PR updates the tensile test scripts to include a libtock-rs 15.4 tx/rx test. This replaces https://github.com/tock/tock-hardware-ci/pull/46 and is deployed on the staging branch (so we can confirm this update gh workflow functions properly).

## Testing

Treadmill job replicating steps initiated by nightly tensile test.